### PR TITLE
Pdaf ipda refactor

### DIFF
--- a/vortex-filtering/include/vortex_filtering/filters/immipda.hpp
+++ b/vortex-filtering/include/vortex_filtering/filters/immipda.hpp
@@ -218,8 +218,7 @@ class IMMIPDA {
 
         // Calculate existence probability (7.32-7.33)
         double existence_prob_upd = IPDA_<0>::existence_prob_update(
-            hypothesis_likelihoods, existence_prob_est,
-            {config.pdaf, config.ipda});
+            hypothesis_likelihoods, existence_prob_est, config.pdaf);
 
         return {
             .state =

--- a/vortex-filtering/include/vortex_filtering/filters/ipda.hpp
+++ b/vortex-filtering/include/vortex_filtering/filters/ipda.hpp
@@ -112,14 +112,15 @@ class IPDA {
         double existence_prob_pred,
         const Config& config) {
         typename PDAF::Config pdaf_cfg{.pdaf = config.pdaf};
-        auto [x_post, x_updates, gated_measurements, z_inside_meas] =
+        auto [x_post, x_updates, gated_measurements, z_inside_meas,
+              z_likelihoods] =
             PDAF::update(sens_mod, x_pred, z_pred, z_measurements, pdaf_cfg);
 
         double existence_prob_upd = existence_prob_pred;
         if (z_measurements.cols() > 0 ||
             config.ipda.update_existence_probability_on_no_detection) {
             existence_prob_upd = existence_prob_update(
-                z_inside_meas, z_pred, existence_prob_pred, config);
+                z_likelihoods, existence_prob_pred, config);
         }
 
         return std::make_tuple(x_post, x_updates, gated_measurements,

--- a/vortex-filtering/include/vortex_filtering/filters/ipda.hpp
+++ b/vortex-filtering/include/vortex_filtering/filters/ipda.hpp
@@ -182,36 +182,6 @@ class IPDA {
     }
 
     /**
-     * @brief Calculates the existence probability given the measurements
-     * and the previous existence probability.
-     * @param z_measurements The measurements to iterate over.
-     * @param z_pred The predicted measurement.
-     * @param existence_prob_est (r_{k-1}) The previous existence
-     * probability.
-     * @param config The configuration for the IPDA.
-     * @return The existence probability.
-     */
-    static double existence_prob_update(const Arr_zXd& z_measurements,
-                                        const Gauss_z& z_pred,
-                                        double existence_prob_pred,
-                                        Config config) {
-        double r_kgkm1 = existence_prob_pred;
-        double P_d = config.pdaf.prob_of_detection;
-        double lambda = config.pdaf.clutter_intensity;
-
-        // predicted measurement likelihood sum
-        double z_pred_prob = 0.0;
-        for (const typename T::Vec_z& z_k : z_measurements.colwise()) {
-            z_pred_prob += z_pred.pdf(z_k);
-        }
-
-        // posterior existence probability r_k
-        double L_k = 1 - P_d + P_d / lambda * z_pred_prob;         // (7.33)
-        double r_k = (L_k * r_kgkm1) / (1 - (1 - L_k) * r_kgkm1);  // (7.32)
-        return r_k;
-    }
-
-    /**
      * @brief Calculates the existence probability given the likelihood of the
      * measurements and the previous existence probability.
      * @param z_likelyhoods (l_a_k) The likelihood of the measurements

--- a/vortex-filtering/include/vortex_filtering/filters/ipda.hpp
+++ b/vortex-filtering/include/vortex_filtering/filters/ipda.hpp
@@ -57,16 +57,16 @@ class IPDA {
      * predicted target existence probability.
      *
      * @note
-     * Corresponds to quantities at time step \f$k|k-1\f$.
+     * Corresponds to quantities at time step k|k-1.
      */
     struct PredictionResult {
-        /// Predicted state estimate \f$x_{k|k-1}\f$
+        /// Predicted state estimate x_{k|k-1}
         Gauss_x x_pred;
 
-        /// Predicted measurement distribution \f$z_{k|k-1}\f$
+        /// Predicted measurement distribution z_{k|k-1}
         Gauss_z z_pred;
 
-        /// Predicted target existence probability \f$r_{k|k-1}\f$
+        /// Predicted target existence probability r_{k|k-1}
         double existence_prob_pred;
     };
 
@@ -83,7 +83,7 @@ class IPDA {
      * configuration
      */
     struct UpdateResult {
-        /// Posterior state estimate after IPDA update \f$x_{k|k}\f$
+        /// Posterior state estimate after IPDA update x_{k|k}
         Gauss_x x_post;
 
         /// State updates conditioned on each gated measurement
@@ -96,7 +96,7 @@ class IPDA {
         /// Measurements inside the validation gate
         Arr_zXd z_inside_meas;
 
-        /// Updated target existence probability \f$r_k\f$
+        /// Updated target existence probability r_k
         double existence_prob_upd;
 
         /// Clutter intensity used during the update
@@ -110,18 +110,18 @@ class IPDA {
      * suitable for external use, logging, or higher-level filters (e.g. IMM).
      *
      * @note
-     * - `state.x_estimate` corresponds to \f$x_{k|k}\f$
-     * - `x_pred` corresponds to \f$x_{k|k-1}\f$
+     * - `state.x_estimate` corresponds to x_{k|k}
+     * - `x_pred` corresponds to x_{k|k-1}
      * - `clutter_intensity` is the value actually used in the PDAF update
      */
     struct StepResult {
         /// Updated target state and existence probability
         State state;
 
-        /// Predicted state estimate \f$x_{k|k-1}\f$
+        /// Predicted state estimate x_{k|k-1}
         Gauss_x x_pred;
 
-        /// Predicted measurement distribution \f$z_{k|k-1}\f$
+        /// Predicted measurement distribution z_{k|k-1}
         Gauss_z z_pred;
 
         /// State updates conditioned on each gated measurement

--- a/vortex-filtering/include/vortex_filtering/filters/ipda.hpp
+++ b/vortex-filtering/include/vortex_filtering/filters/ipda.hpp
@@ -28,6 +28,10 @@ class IPDA {
 
     using T = Types_xzuvw<N_DIM_x, N_DIM_z, N_DIM_u, N_DIM_v, N_DIM_w>;
 
+    using Gauss_z = typename T::Gauss_z;
+    using Gauss_x = typename T::Gauss_x;
+    using Gauss_xX = std::vector<Gauss_x>;
+
     using Arr_zXd = Eigen::Array<double, N_DIM_z, Eigen::Dynamic>;
     using Arr_1Xb = Eigen::Array<bool, 1, Eigen::Dynamic>;
     using EKF =
@@ -42,18 +46,133 @@ class IPDA {
     };
 
     struct State {
-        T::Gauss_x x_estimate;
+        Gauss_x x_estimate;
         double existence_probability;
     };
 
     struct Output {
         State state;
-        T::Gauss_x x_prediction;
-        T::Gauss_z z_prediction;
-        std::vector<typename T::Gauss_x> x_updates;
+        Gauss_x x_prediction;
+        Gauss_z z_prediction;
+        Gauss_xX x_updates;
         Arr_1Xb gated_measurements;
     };
 
+    /**
+     * @brief Perform one IPDA prediction step
+     *
+     * @param dyn_mod The dynamic model
+     * @param sens_mod The sensor model
+     * @param dt Time step in seconds
+     * @param state_est_prev The previous estimated state
+     * @param z_measurements Array of measurements
+     * @param config Configuration for the IPDA
+     * @return `std::tuple<Gauss_x, Gauss_z, double>` The predicted state,
+     * predicted measurement, and predicted existence probability
+     */
+    static std::tuple<Gauss_x, Gauss_z, double> predict(
+        const DynModT dyn_mod,
+        const SensModT& sens_mod,
+        double dt,
+        const State& state_est_prev,
+        const Arr_zXd& z_measurements,
+        Config& config) {
+        double existence_prob_pred = existence_prediction(
+            state_est_prev.existence_probability, config.ipda.prob_of_survival);
+
+        auto [x_pred, z_pred] =
+            EKF::predict(dyn_mod, sens_mod, dt, state_est_prev.x_estimate);
+
+        if (config.ipda.estimate_clutter) {
+            config.pdaf.clutter_intensity = estimate_clutter_intensity(
+                z_pred, existence_prob_pred, z_measurements.cols(), config);
+        }
+
+        return {x_pred, z_pred, existence_prob_pred};
+    }
+
+    /**
+     * @brief Performs one IPDA update step
+     * @param sens_mod The sensor model
+     * @param x_pred The predicted state
+     * @param z_pred The predicted measurement
+     * @param z_measurements Array of measurements
+     * @param existence_prob_pred The predicted existence probability
+     * @param config Configuration for the IPDA
+     * @return `std::tuple<Gauss_x, Gauss_xX, Arr_1Xb, Arr_zXd, double>` The
+     * updated state, all updated states for each measurement, the indices of
+     * the measurements that are inside the gate, the measurements that are
+     * inside the gate and the updated existence probability
+     */
+    static std::tuple<Gauss_x, Gauss_xX, Arr_1Xb, Arr_zXd, double> update(
+        const SensModT& sens_mod,
+        const Gauss_x& x_pred,
+        const Gauss_z& z_pred,
+        const Arr_zXd& z_measurements,
+        double existence_prob_pred,
+        const Config& config) {
+        typename PDAF::Config pdaf_cfg{.pdaf = config.pdaf};
+        auto [x_post, x_updates, gated_measurements, z_inside_meas] =
+            PDAF::update(sens_mod, x_pred, z_pred, z_measurements, pdaf_cfg);
+
+        double existence_prob_upd = existence_prob_pred;
+        if (z_measurements.cols() > 0 ||
+            config.ipda.update_existence_probability_on_no_detection) {
+            existence_prob_upd = existence_prob_update(
+                z_inside_meas, z_pred, existence_prob_pred, config);
+        }
+
+        return std::make_tuple(x_post, x_updates, gated_measurements,
+                               z_inside_meas, existence_prob_upd);
+    }
+
+    /**
+     * @brief Perform one step of the Integrated Probabilistic Data Association
+     * Filter
+     *
+     * @param dyn_mod The dynamic model
+     * @param sens_mod The sensor model
+     * @param dt Time step in seconds
+     * @param state_est_prev The previous estimated state
+     * @param z_measurements Array of measurements
+     * @param config Configuration for the IPDA
+     * @return `Output` The result of the IPDA step and some intermediate
+     * results
+     */
+    static Output step(const DynModT& dyn_mod,
+                       const SensModT& sens_mod,
+                       double dt,
+                       const State& state_est_prev,
+                       const Arr_zXd& z_measurements,
+                       Config& config) {
+        auto [x_pred, z_pred, existence_prob_pred] = predict(
+            dyn_mod, sens_mod, dt, state_est_prev, z_measurements, config);
+
+        auto [x_post, x_updates, gated_measurements, z_inside_meas,
+              existence_prob_upd] =
+            update(sens_mod, x_pred, z_pred, z_measurements,
+                   existence_prob_pred, config);
+
+        // clang-format off
+        return {
+            .state = {
+                .x_estimate            = x_post,
+                .existence_probability = existence_prob_upd,
+            },
+            .x_prediction       = x_pred,
+            .z_prediction       = z_pred,
+            .x_updates          = x_updates,
+            .gated_measurements = gated_measurements
+        };
+        // clang-format on
+    }
+
+    /**
+     * @brief Calculates the predicted existence probability
+     * @param existence_prob_est (r_{k-1}) The previous existence probability.
+     * @param prob_of_survival (P_s) The probability of survival.
+     * @return The predicted existence probability (r_{k|k-1}).
+     */
     static double existence_prediction(double existence_prob_est,
                                        double prob_of_survival) {
         double r_km1 = existence_prob_est;
@@ -62,23 +181,24 @@ class IPDA {
     }
 
     /**
-     * @brief Calculates the existence probability given the measurements and
-     * the previous existence probability.
+     * @brief Calculates the existence probability given the measurements
+     * and the previous existence probability.
      * @param z_measurements The measurements to iterate over.
      * @param z_pred The predicted measurement.
-     * @param existence_prob_est (r_{k-1}) The previous existence probability.
+     * @param existence_prob_est (r_{k-1}) The previous existence
+     * probability.
      * @param config The configuration for the IPDA.
      * @return The existence probability.
      */
     static double existence_prob_update(const Arr_zXd& z_measurements,
-                                        T::Gauss_z& z_pred,
+                                        const Gauss_z& z_pred,
                                         double existence_prob_pred,
                                         Config config) {
         double r_kgkm1 = existence_prob_pred;
         double P_d = config.pdaf.prob_of_detection;
         double lambda = config.pdaf.clutter_intensity;
 
-        // predicted measurement probability
+        // predicted measurement likelihood sum
         double z_pred_prob = 0.0;
         for (const typename T::Vec_z& z_k : z_measurements.colwise()) {
             z_pred_prob += z_pred.pdf(z_k);
@@ -114,20 +234,19 @@ class IPDA {
     /**
      * @brief Estimates the clutter intensity using (7.31)
      * @param z_pred The predicted measurement.
-     * @param predicted_existence_probability (r_{k|k-1})  The predicted
+     * @param existence_prob_pred (r_{k|k-1})  The predicted
      * existence probability.
      * @param num_measurements (m_k) The number of z_measurements.
      * @param config The configuration for the IPDA.
      * @return The clutter intensity.
      */
-    static double estimate_clutter_intensity(
-        const T::Gauss_z& z_pred,
-        double predicted_existence_probability,
-        double num_measurements,
-        Config config) {
+    static double estimate_clutter_intensity(const Gauss_z& z_pred,
+                                             double existence_prob_pred,
+                                             double num_measurements,
+                                             Config config) {
         size_t m_k = num_measurements;
         double P_d = config.pdaf.prob_of_detection;
-        double r_k = predicted_existence_probability;
+        double r_k = existence_prob_pred;
         double V_k =
             utils::Ellipsoid<N_DIM_z>(z_pred, config.pdaf.mahalanobis_threshold)
                 .volume();  // gate area
@@ -136,50 +255,6 @@ class IPDA {
             return 0.0;
         }
         return 1 / V_k * (m_k - r_k * P_d);  // (7.31)
-    }
-
-    static Output step(const DynModT& dyn_mod,
-                       const SensModT& sens_mod,
-                       double timestep,
-                       const State& state_est_prev,
-                       const Arr_zXd& z_measurements,
-                       Config& config) {
-        double existence_prob_pred = existence_prediction(
-            state_est_prev.existence_probability, config.ipda.prob_of_survival);
-
-        if (config.ipda.estimate_clutter) {
-            typename T::Gauss_z z_pred;
-            std::tie(std::ignore, z_pred) = EKF::predict(
-                dyn_mod, sens_mod, timestep, state_est_prev.x_estimate);
-            config.pdaf.clutter_intensity = estimate_clutter_intensity(
-                z_pred, existence_prob_pred, z_measurements.cols(), config);
-        }
-
-        auto [x_post, x_pred, z_pred, x_upd, gated_measurements] =
-            PDAF::step(dyn_mod, sens_mod, timestep, state_est_prev.x_estimate,
-                       z_measurements, {config.pdaf});
-
-        Arr_zXd z_meas_inside =
-            PDAF::get_inside_measurements(z_measurements, gated_measurements);
-
-        double existence_probability_upd = existence_prob_pred;
-        if (!(z_measurements.cols() == 0 &&
-              config.ipda.update_existence_probability_on_no_detection)) {
-            existence_probability_upd = existence_prob_update(
-                z_meas_inside, z_pred, existence_prob_pred, config);
-        }
-        // clang-format off
-    return {
-      .state = {
-        .x_estimate            = x_post,
-        .existence_probability = existence_probability_upd,
-      },
-      .x_prediction       = x_pred,
-      .z_prediction       = z_pred,
-      .x_updates          = x_upd,
-      .gated_measurements = gated_measurements
-    };
-        // clang-format on
     }
 };
 }  // namespace vortex::filter

--- a/vortex-filtering/include/vortex_filtering/filters/pdaf.hpp
+++ b/vortex-filtering/include/vortex_filtering/filters/pdaf.hpp
@@ -185,6 +185,28 @@ class PDAF {
     }
 
     /**
+     * @brief Get the measurement likelihoods
+     *
+     * @param z_pred The predicted measurement
+     * @param z_measurements The measurements
+     *
+     * @return `Eigen::ArrayXd` The measurement likelihoods
+     */
+    static Eigen::ArrayXd get_measurement_likelihoods(
+        const Gauss_z& z_pred,
+        const Arr_zXd& z_measurements) {
+        const int m = z_measurements.cols();
+        Eigen::ArrayXd meas_likelihoods(m);
+
+        int i = 0;
+        for (const Vec_z& z_k : z_measurements.colwise()) {
+            meas_likelihoods(i++) = z_pred.pdf(z_k);
+        }
+
+        return meas_likelihoods;
+    }
+
+    /**
      * @brief Get the weighted average of the states
      *
      * @param z_measurements Array of measurements

--- a/vortex-filtering/test/ipda_test.cpp
+++ b/vortex-filtering/test/ipda_test.cpp
@@ -2,11 +2,13 @@
 #include <gtest/gtest.h>
 #include <iostream>
 #include <vortex_filtering/filters/ipda.hpp>
+#include <vortex_filtering/filters/pdaf.hpp>
 #include <vortex_filtering/utils/plotting.hpp>
 
 using ConstantVelocity = vortex::models::ConstantVelocity;
 using IdentitySensorModel = vortex::models::IdentitySensorModel<4, 2>;
 using IPDA = vortex::filter::IPDA<ConstantVelocity, IdentitySensorModel>;
+using PDAF = vortex::filter::PDAF<ConstantVelocity, IdentitySensorModel>;
 
 TEST(IPDA, ipda_runs) {
     IPDA::Config config = {
@@ -65,8 +67,11 @@ TEST(IPDA, get_existence_probability_is_calculating) {
     vortex::prob::Gauss2d z_pred = {{1.0, 1.0},
                                     Eigen::Matrix2d::Identity() * 0.1};
 
+    Eigen::ArrayXd z_likelihoods =
+        PDAF::get_measurement_likelihoods(z_pred, meas);
+
     double existence_probability = IPDA::existence_prob_update(
-        meas, z_pred, last_detection_probability, config);
+        z_likelihoods, last_detection_probability, config);
 
     std::cout << "Existence probability: " << existence_probability
               << std::endl;

--- a/vortex-filtering/test/ipda_test.cpp
+++ b/vortex-filtering/test/ipda_test.cpp
@@ -38,7 +38,8 @@ TEST(IPDA, ipda_runs) {
     ConstantVelocity dyn_model{1.0};
     IdentitySensorModel sen_model{1.0};
 
-    auto [state_post, x_pred, z_pred, x_updated, gated_measurements] =
+    auto [state_post, x_pred, z_pred, x_updated, gated_measurements,
+          clutter_intensity] =
         IPDA::step(dyn_model, sen_model, 1.0,
                    {x_est, last_detection_probability}, z_meas, config);
 
@@ -71,7 +72,7 @@ TEST(IPDA, get_existence_probability_is_calculating) {
         PDAF::get_measurement_likelihoods(z_pred, meas);
 
     double existence_probability = IPDA::existence_prob_update(
-        z_likelihoods, last_detection_probability, config);
+        z_likelihoods, last_detection_probability, config.pdaf);
 
     std::cout << "Existence probability: " << existence_probability
               << std::endl;

--- a/vortex-filtering/test/pdaf_test.cpp
+++ b/vortex-filtering/test/pdaf_test.cpp
@@ -17,8 +17,11 @@ TEST(PDAF, get_weights_is_calculating) {
                                  Eigen::Matrix2d::Identity());
     Eigen::Array2Xd meas = {{0.0, 2.0}, {0.0, 1.0}};
 
+    Eigen::ArrayXd z_likelihoods =
+        PDAF::get_measurement_likelihoods(z_pred, meas);
+
     Eigen::VectorXd weights =
-        PDAF::get_weights(meas, z_pred, prob_of_detection, clutter_intensity);
+        PDAF::get_weights(z_likelihoods, prob_of_detection, clutter_intensity);
 
     std::cout << "weights: " << weights << std::endl;
 
@@ -33,8 +36,11 @@ TEST(PDAF, if_no_clutter_first_weight_is_zero) {
                                  Eigen::Matrix2d::Identity());
     Eigen::Array2Xd meas = {{0.0, 2.0}, {0.0, 1.0}};
 
+    Eigen::ArrayXd z_likelihoods =
+        PDAF::get_measurement_likelihoods(z_pred, meas);
+
     Eigen::VectorXd weights =
-        PDAF::get_weights(meas, z_pred, prob_of_detection, clutter_intensity);
+        PDAF::get_weights(z_likelihoods, prob_of_detection, clutter_intensity);
 
     std::cout << "weights: " << weights << std::endl;
 
@@ -49,8 +55,11 @@ TEST(PDAF, weights_are_decreasing_with_distance) {
                                  Eigen::Matrix2d::Identity());
     Eigen::Array2Xd meas = {{2.0, 3.0, 4.0}, {1.0, 1.0, 1.0}};
 
+    Eigen::ArrayXd z_likelihoods =
+        PDAF::get_measurement_likelihoods(z_pred, meas);
+
     Eigen::VectorXd weights =
-        PDAF::get_weights(meas, z_pred, prob_of_detection, clutter_intensity);
+        PDAF::get_weights(z_likelihoods, prob_of_detection, clutter_intensity);
 
     std::cout << "weights: " << weights << std::endl;
 
@@ -74,8 +83,11 @@ TEST(PDAF, get_weighted_average_is_calculating) {
         vortex::prob::Gauss4d(Eigen::Vector4d(1.0, 1.0, 1.0, 1.0),
                               Eigen::Matrix4d::Identity())};
 
+    Eigen::ArrayXd z_likelihoods =
+        PDAF::get_measurement_likelihoods(z_pred, meas);
+
     vortex::prob::Gauss4d weighted_average =
-        PDAF::get_weighted_average(meas, updated_states, z_pred, x_pred,
+        PDAF::get_weighted_average(z_likelihoods, updated_states, x_pred,
                                    prob_of_detection, clutter_intensity);
 
     std::cout << "weighted average: " << weighted_average.mean() << std::endl;
@@ -94,8 +106,11 @@ TEST(PDAF, average_state_is_in_between_prediction_and_measurement_y_axis) {
     std::vector<vortex::prob::Gauss4d> updated_states = {vortex::prob::Gauss4d(
         Eigen::Vector4d(1.0, 1.5, 0.0, 0.0), Eigen::Matrix4d::Identity())};
 
+    Eigen::ArrayXd z_likelihoods =
+        PDAF::get_measurement_likelihoods(z_pred, meas);
+
     vortex::prob::Gauss4d weighted_average =
-        PDAF::get_weighted_average(meas, updated_states, z_pred, x_pred,
+        PDAF::get_weighted_average(z_likelihoods, updated_states, x_pred,
                                    prob_of_detection, clutter_intensity);
 
     EXPECT_GT(weighted_average.mean()(1), x_pred.mean()(1));
@@ -119,8 +134,11 @@ TEST(PDAF, average_state_is_in_between_prediction_and_measurement_x_axis) {
     std::vector<vortex::prob::Gauss4d> updated_states = {vortex::prob::Gauss4d(
         Eigen::Vector4d(1.5, 1.0, 0.0, 0.0), Eigen::Matrix4d::Identity())};
 
+    Eigen::ArrayXd z_likelihoods =
+        PDAF::get_measurement_likelihoods(z_pred, meas);
+
     vortex::prob::Gauss4d weighted_average =
-        PDAF::get_weighted_average(meas, updated_states, z_pred, x_pred,
+        PDAF::get_weighted_average(z_likelihoods, updated_states, x_pred,
                                    prob_of_detection, clutter_intensity);
 
     EXPECT_GT(weighted_average.mean()(0), x_pred.mean()(0));
@@ -144,8 +162,11 @@ TEST(PDAF, average_state_is_in_between_prediction_and_measurement_both_axes) {
     std::vector<vortex::prob::Gauss4d> updated_states = {vortex::prob::Gauss4d(
         Eigen::Vector4d(1.5, 1.5, 0.0, 0.0), Eigen::Matrix4d::Identity())};
 
+    Eigen::ArrayXd z_likelihoods =
+        PDAF::get_measurement_likelihoods(z_pred, meas);
+
     vortex::prob::Gauss4d weighted_average =
-        PDAF::get_weighted_average(meas, updated_states, z_pred, x_pred,
+        PDAF::get_weighted_average(z_likelihoods, updated_states, x_pred,
                                    prob_of_detection, clutter_intensity);
 
     EXPECT_GT(weighted_average.mean()(0), x_pred.mean()(0));


### PR DESCRIPTION
Split the steps function of PDAF and IPDA into separate predict and update functions. 
Added z_likelihood function.
Removed redundant z_likelihood calculation in IPDA.

Fixed this if-statement bug that negated the function of the config arg.
```cpp
        if (!(z_measurements.cols() == 0 &&
              config.ipda.update_existence_probability_on_no_detection)) {
            existence_probability_upd = existence_prob_update(
                z_meas_inside, z_pred, existence_prob_pred, config);
        }
```